### PR TITLE
Spacer fix

### DIFF
--- a/mixins/Menu.lua
+++ b/mixins/Menu.lua
@@ -108,8 +108,10 @@ function menuMixin:UpdateLine(index, data)
 	Line.Expand:Hide()
 	Line.ColorSwatch:Hide()
 	Line.Texture:Hide()
+	Line.Spacer:Hide()
 
 	if(data.isSpacer) then
+		Line:SetText("")
 		Line.Spacer:Show()
 		Line:EnableMouse(false)
 	elseif(data.isTitle) then
@@ -120,7 +122,6 @@ function menuMixin:UpdateLine(index, data)
 		Line:SetNormalFontObject(self.parent.titleFont)
 	else
 		Line:EnableMouse(true)
-		Line.Spacer:Hide()
 
 		if(data.font) then
 			Line.Text:SetFont(data.font, data.fontSize or 12, data.fontFlags)

--- a/mixins/Menu.lua
+++ b/mixins/Menu.lua
@@ -112,7 +112,6 @@ function menuMixin:UpdateLine(index, data)
 	if(data.isSpacer) then
 		Line.Spacer:Show()
 		Line:EnableMouse(false)
-		return Line
 	elseif(data.isTitle) then
 		local text = data.text
 		assert(text and type(text) == 'string', 'Missing required data "text"')


### PR DESCRIPTION
A few bugs related to spacer lines.

1. If a line is hidden when it is set as a spacer, it won't be shown
2. If a line was previously a text or header line, the text will still be visible.