### PR TITLE
Text fix

### DIFF
--- a/mixins/Menu.lua
+++ b/mixins/Menu.lua
@@ -11,7 +11,12 @@ local function OnShow(self)
 
 	for _, Line in next, self.lines do
 		if(Line:IsShown()) then
-			local lineWidth = Line.Text:GetWidth() + 50
+			local lineWidth
+			if(Line.Text:IsShown()) then
+				lineWidth = Line.Text:GetWidth()
+			else
+				lineWidth = Line:GetTextWidth()
+			end
 			lineWidth = math.max(lineWidth, minWidth)
 
 			if(maxWidth) then
@@ -133,16 +138,16 @@ function menuMixin:UpdateLine(index, data)
 			Line.Text:Show()
 		else
 			if(data.fontObject) then
-			Line:SetNormalFontObject(data.fontObject)
-			Line:SetHighlightFontObject(data.fontObject)
-			Line:SetDisabledFontObject(data.fontObject)
-		else
-			Line:SetNormalFontObject(self.parent.normalFont)
-			Line:SetHighlightFontObject(self.parent.highlightFont)
-			Line:SetDisabledFontObject(self.parent.disabledFont)
-		end
+				Line:SetNormalFontObject(data.fontObject)
+				Line:SetHighlightFontObject(data.fontObject)
+				Line:SetDisabledFontObject(data.fontObject)
+			else
+				Line:SetNormalFontObject(self.parent.normalFont)
+				Line:SetHighlightFontObject(self.parent.highlightFont)
+				Line:SetDisabledFontObject(self.parent.disabledFont)
+			end
 
-		Line:SetText(text)
+			Line:SetText(text)
 		end
 
 		Line:SetTexture(data.texture, data.textureColor)

--- a/mixins/Menu.lua
+++ b/mixins/Menu.lua
@@ -108,6 +108,7 @@ function menuMixin:UpdateLine(index, data)
 	Line.Expand:Hide()
 	Line.ColorSwatch:Hide()
 	Line.Texture:Hide()
+	Line.Text:Hide()
 
 	if(data.isSpacer) then
 		Line.Spacer:Show()
@@ -123,9 +124,15 @@ function menuMixin:UpdateLine(index, data)
 		Line:EnableMouse(true)
 		Line.Spacer:Hide()
 
+		local text = data.text
+		assert(text and type(text) == 'string', 'Missing required data "text"')
+
 		if(data.font) then
 			Line.Text:SetFont(data.font, data.fontSize or 12, data.fontFlags)
-		elseif(data.fontObject) then
+			Line.Text:SetText(text)
+			Line.Text:Show()
+		else
+			if(data.fontObject) then
 			Line:SetNormalFontObject(data.fontObject)
 			Line:SetHighlightFontObject(data.fontObject)
 			Line:SetDisabledFontObject(data.fontObject)
@@ -135,10 +142,9 @@ function menuMixin:UpdateLine(index, data)
 			Line:SetDisabledFontObject(self.parent.disabledFont)
 		end
 
-		local text = data.text
-		assert(text and type(text) == 'string', 'Missing required data "text"')
-
 		Line:SetText(text)
+		end
+
 		Line:SetTexture(data.texture, data.textureColor)
 
 		if(data.icon) then


### PR DESCRIPTION
A few bugs for text lines:

1. `Line.Text` never gets shown, even if `data.font` is set.
2. `Line.Text` never gets text set to it, so even when shown nothing would display.
3. Only `Line.Text` was used to determine menu width, which was likely always 0.