### PR TITLE
Icon fix

### DIFF
--- a/mixins/Line.lua
+++ b/mixins/Line.lua
@@ -169,7 +169,7 @@ end
 Updates the Line text.
 --]]
 function lineMixin:UpdateText()
-	local text = self:GetText():gsub('|T.*|t'):gsub('|A.*|a')
+	local text = self:GetText():gsub('|T.*|t', ''):gsub('|A.*|a', '')
 	self:SetText(text)
 end
 

--- a/mixins/Line.lua
+++ b/mixins/Line.lua
@@ -129,7 +129,7 @@ See [FrameXML/Util.lua's CreateTextureMarkup](https://www.townlong-yak.com/frame
 --]]
 function lineMixin:SetIcon(...)
 	local markup = CreateTextureMarkup(...)
-	self.__icon = markup
+	self.__icon = markup..' '
 	self:UpdateText()
 end
 
@@ -145,7 +145,7 @@ See [FrameXML/Util.lua's CreateAtlasMarkup](https://www.townlong-yak.com/framexm
 --]]
 function lineMixin:SetAtlas(...)
 	local markup = CreateAtlasMarkup(...)
-	self.__atlas = markup
+	self.__atlas = markup..' '
 	self:UpdateText()
 end
 


### PR DESCRIPTION
If an icon or atlas is added to a line, I get this error:
```lua
x1  ...ce\nibRealUI\Libs\LibDropDown-2\mixins/Line.lua:172: bad argument #2 to 'gsub' (string/function/table expected)
Stack: [C] in function 'gsub'
...ce\nibRealUI\Libs\LibDropDown-2\mixins/Line.lua:172: in function 'UpdateText'
...ce\nibRealUI\Libs\LibDropDown-2\mixins/Line.lua:133: in function 'SetIcon'
...ce\nibRealUI\Libs\LibDropDown-2\mixins/Menu.lua:155: in function 'UpdateLine'
...ce\nibRealUI\Libs\LibDropDown-2\mixins/Menu.lua:312: in function 'AddLine'
...ce\nibRealUI\Libs\LibDropDown-2\mixins/Menu.lua:243: in function 'AddLines'
...ce\nibRealUI\Libs\LibDropDown-2\mixins/Menu.lua:316: in function 'AddLine'
...ce\nibRealUI\Libs\LibDropDown-2\mixins/Menu.lua:243: in function 'AddLines'
nibRealUI\Modules\MinimapAdv.lua:1702: in function <nibRealUI\Modules\MinimapAdv.lua:1571>
nibRealUI\Modules\MinimapAdv.lua:1886: in function <nibRealUI\Modules\MinimapAdv.lua:1883>
(tail call): ?
[C] ?
[string "safecall Dispatcher[1]"]:9: in function <[string "safecall Dispatcher[1]"]:5>
(tail call): ?
...ace\Masque\Libs\AceAddon-3.0\AceAddon-3.0-12.lua:558: in function 'EnableAddon'
...ace\Masque\Libs\AceAddon-3.0\AceAddon-3.0-12.lua:571: in function 'EnableAddon'
...ace\Masque\Libs\AceAddon-3.0\AceAddon-3.0-12.lua:651: in function <...ace\Masque\Libs\AceAddon-3.0\AceAddon-3.0.lua:636>
[C] in function 'LoadAddOn'
FrameXML\UIParent.lua:445: in function 'UIParentLoadAddOn'
FrameXML\UIParent.lua:564: in function 'TimeManager_LoadUI'
FrameXML\UIParent.lua:1191: in function <FrameXML\UIParent.lua:1089>
Time: 2018/07/27 14:11:45 Index: 1/1
RealUI Version: 2.0.2
Locals:
```

This also adds a space after the texture to provide more breathing room between it and the text.